### PR TITLE
Remove excess metadata section in diamond.yaml

### DIFF
--- a/examples/hello_workflow/diamond.yaml
+++ b/examples/hello_workflow/diamond.yaml
@@ -3,8 +3,6 @@ kind: Workflow
 metadata:
   name: diamond
 spec:
-  metadata:
-    name: diamond
   selector:
     matchLabels:
       workflow: diamond


### PR DESCRIPTION
Issue #43: excess metadata section in diamond.yaml example.