### PR TITLE
cronWorkflowSpec.antiSchedule must be optional

### DIFF
--- a/pkg/api/cronworkflow/v1/types.go
+++ b/pkg/api/cronworkflow/v1/types.go
@@ -61,7 +61,7 @@ type CronWorkflowSpec struct {
 	Schedule string `json:"schedule"`
 
 	// The anti schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-	AntiSchedule string `json:"antischedule"`
+	AntiSchedule string `json:"antischedule,omitempty"`
 
 	// Optional deadline in seconds for starting the workflow if it misses scheduled
 	// time for any reason.  Missed workflows executions will be counted as failed ones.


### PR DESCRIPTION
No need to be pointer since it's a string