### PR TITLE
HO test funcs cleanup

### DIFF
--- a/pkg/controller/daemonsetjob.go
+++ b/pkg/controller/daemonsetjob.go
@@ -219,7 +219,7 @@ func (d *DaemonSetJobController) sync(key string) error {
 	var sharedDaemonSetJob *dapi.DaemonSetJob
 	var err error
 	if sharedDaemonSetJob, err = d.getDaemonSetJobByKey(key); err != nil {
-		glog.Errorf("unable to get Workflow %s: %v. Maybe deleted", key, err)
+		glog.V(4).Infof("unable to get Workflow %s: %v. Maybe deleted", key, err)
 		return nil
 	}
 	namespace := sharedDaemonSetJob.Namespace
@@ -582,7 +582,7 @@ func (d *DaemonSetJobController) getDaemonSetJobByKey(key string) (*dapi.DaemonS
 	glog.V(6).Infof("Syncing %s/%s", namespace, name)
 	daemonsetJob, err := d.DaemonSetJobLister.DaemonSetJobs(namespace).Get(name)
 	if err != nil {
-		glog.Errorf("unable to get DaemonSetJob %s/%s: %v. Maybe deleted", namespace, name, err)
+		glog.V(4).Infof("unable to get DaemonSetJob %s/%s: %v. Maybe deleted", namespace, name, err)
 		return nil, err
 	}
 	return daemonsetJob, nil

--- a/pkg/controller/workflow.go
+++ b/pkg/controller/workflow.go
@@ -197,7 +197,7 @@ func (w *WorkflowController) getWorkflowByKey(key string) (*wapi.Workflow, error
 	glog.V(6).Infof("Syncing %s/%s", namespace, name)
 	workflow, err := w.WorkflowLister.Workflows(namespace).Get(name)
 	if err != nil {
-		glog.Errorf("unable to get Workflow %s/%s: %v. Maybe deleted", namespace, name, err)
+		glog.V(4).Infof("unable to get Workflow %s/%s: %v. Maybe deleted", namespace, name, err)
 		return nil, err
 	}
 	return workflow, nil
@@ -213,7 +213,7 @@ func (w *WorkflowController) sync(key string) error {
 	var sharedWorkflow *wapi.Workflow
 	var err error
 	if sharedWorkflow, err = w.getWorkflowByKey(key); err != nil {
-		glog.Errorf("unable to get Workflow %s: %v. Maybe deleted", key, err)
+		glog.V(4).Infof("unable to get Workflow %s: %v. Maybe deleted", key, err)
 		return nil
 	}
 	namespace := sharedWorkflow.Namespace


### PR DESCRIPTION
Hi workflowers,

2 things in this PR:

1. Related to controllers verbosity
2. Related to test e2e promiscuity

The first one is simple: when an item has been deleted stop log the error raising error to `v(4)`

Second one: unluckily some of our test e2e are a little bit too promiscuous while checking if workflow or daemonsetjob has been created.
Goal of this PR is to restrict the scope.
Why?
Developing cronworklows I realized that sometime some workflows generated by cronworkflows were picked up by the workflows.list funcs
The idea is: stop list simply get what is needed.

Hope it's clear.